### PR TITLE
Fix line intersect bug

### DIFF
--- a/Polygon/src/com/sromku/polygon/Line.java
+++ b/Polygon/src/com/sromku/polygon/Line.java
@@ -50,7 +50,12 @@ public class Line
         	}
         	float tx = (point.x - _start.x) / (_end.x - _start.x);
         	float ty = (point.y - _start.y) / (_end.y - _start.y);
-        	return (tx == ty) && (tx >= 0) && (tx <= 1);
+        	
+		if ((tx >= 0) && (tx <= 1) && (ty >= 0) && (ty <= 1)) {
+            		return (1 - Math.abs(tx / ty)) < 0.0001;
+        	}
+
+        	return  false;
 	}
 
 	/**


### PR DESCRIPTION
I found this bug on Android, but probably will occur on the Java for desktop also.

With those points (in code for facility):

Polygon polygon = Polygon.Builder()
        .addVertex(new Point(399, 115))
        .addVertex(new Point(658, 115))
        .addVertex(new Point(658, 373))
        .addVertex(new Point(462, 569))
        .addVertex(new Point(203, 569))
        .addVertex(new Point(203, 311))
        .build();

Calling polygon.contains(new Point(493, 266)) returns false.
But the Point is clearly inside. 

Running the debugger I found that the tx and ty, at the isInside(Point) method, are slightly the 
same! 
The values are:
tx = 0.7093973
ty = 0.7093975

With my modification, we do not have the "almost" intercept problem - 
caused by the float precision.